### PR TITLE
Add selected items to selectize control when refreshing options

### DIFF
--- a/autoform-selectize.js
+++ b/autoform-selectize.js
@@ -164,10 +164,12 @@ var _refreshSelectizeOptions = function (selectize, options) {
 
       _.each(option.items, function (groupOption) {
         selectize.addOption({value: groupOption.value, text: groupOption.label, optgroup: option.optgroup});
+        if (groupOption.selected) selectize.addItem(groupOption.value, true);
       });
     } else {
       if (option.value) {
         selectize.addOption({value: option.value, text: option.label});
+        if (option.selected) selectize.addItem(option.value, true);
       }
     }
   });


### PR DESCRIPTION
When initializing the selectize control from a select with already selected options (in an update scenario), selected items were not added to the selectize control’s list of selected items.

This fixes that.