### PR TITLE
Allow package dependencies to update

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,9 +7,13 @@ Package.describe({
 
 Package.onUse(function(api) {
   api.versionsFrom('1.0');
-  api.use('templating@1.0.0');
-  api.use('blaze@2.0.0');
-  api.use('aldeed:autoform@4.0.0');
+
+  api.use([
+    'templating',
+    'blaze',
+    'aldeed:autoform'
+  ]);
+
   api.addFiles([
     'autoform-selectize.html',
     'autoform-selectize.js',


### PR DESCRIPTION
Just an update to package.js to remove the fixed versions and let Autoform and other dependencies update.

[Autoform 5][1] compatibility has been tested and it all seems to be working well on my end.


[1]: https://github.com/aldeed/meteor-autoform/blob/master/CHANGELOG.md