### PR TITLE
lodash compatibility

### DIFF
--- a/autoform-selectize.js
+++ b/autoform-selectize.js
@@ -88,7 +88,7 @@ AutoForm.addInputType("selectize", {
         // See https://github.com/meteor/meteor/issues/2174
         _id: opt.value,
         selected: _.isArray(context.value) ?
-          _.contains(context.value, opt.value) : (opt.value === context.value),
+          _.includes(context.value, opt.value) : (opt.value === context.value),
         // atts: itemAtts
       };
     };


### PR DESCRIPTION
replaces _.contains with _.includes in order to make package compatible with lodash 4.0.0 and underscore

Alternatively, you could add underscore as a dependency in the `package.js` file ? (this might be a better long term solution)