### PR TITLE
Fix issue where destroy() would sometimes be called on a nonexistent object

### DIFF
--- a/autoform-selectize-input.js
+++ b/autoform-selectize-input.js
@@ -77,8 +77,9 @@ Template.afSelectizeInput.rendered = function () {
 };
 
 Template.afSelectizeInput.destroyed = function () {
-  var selectize = this.$('input')[0].selectize;
-  if (selectize) {
+  var input = this.$('input');
+  var selectize = input && input[0] && input[0].selectize;
+  if (selectize && selectize.destroy) {
     selectize.destroy();
   }
 };

--- a/autoform-selectize-input.js
+++ b/autoform-selectize-input.js
@@ -77,5 +77,8 @@ Template.afSelectizeInput.rendered = function () {
 };
 
 Template.afSelectizeInput.destroyed = function () {
-  this.$('input')[0].selectize.destroy();
+  var selectize = this.$('input')[0].selectize;
+  if (selectize) {
+    selectize.destroy();
+  }
 };

--- a/autoform-selectize.js
+++ b/autoform-selectize.js
@@ -182,7 +182,7 @@ Template.afSelectize.rendered = function () {
 Template.afSelectize.destroyed = function () {
   var input = this.$('select');
   var selectize = input && input[0] && input[0].selectize;
-  if (selectize) {
+  if (selectize && selectize.destroy) {
     selectize.destroy();  
   }
 };

--- a/autoform-selectize.js
+++ b/autoform-selectize.js
@@ -180,7 +180,11 @@ Template.afSelectize.rendered = function () {
 };
 
 Template.afSelectize.destroyed = function () {
-  this.$('select')[0].selectize.destroy();
+  var input = this.$('select');
+  var selectize = input && input[0] && input[0].selectize;
+  if (selectize) {
+    selectize.destroy();  
+  }
 };
 
 var _defaults = {


### PR DESCRIPTION
Following same approach @aldeed used here: https://github.com/Meteor-Community-Packages/meteor-autoform-bs-datetimepicker/commit/370184d7ce50778f34ae3941e33b89bf7c0776dd